### PR TITLE
Update translations links

### DIFF
--- a/translations/ARABIC.md
+++ b/translations/ARABIC.md
@@ -10,8 +10,9 @@
 Translations:
 
 - [Arabic](https://github.com/sherifsaleh/reverse-interview/blob/master/translations/ARABIC.md)
-- [English](https://github.com/viraptor/reverse-interview/blob/master/README.md)
+- [Catalan](https://github.com/viraptor/reverse-interview/blob/master/translations/CATALAN.md)
 - Chinese [Simplified](https://github.com/yifeikong/reverse-interview-zh) / [Traditional](https://github.com/NeroCube/reverse-interview-zh-tw/blob/master/README.md)
+- [English](https://github.com/viraptor/reverse-interview/blob/master/README.md)
 - [French](https://github.com/viraptor/reverse-interview/blob/master/translations/FRENCH.md)
 - [Korean](https://github.com/JaeYeopHan/Interview_Question_for_Beginner/blob/master/Reverse_Interview/README.md)
 - [Portuguese (Brazilian)](https://github.com/viraptor/reverse-interview/blob/master/translations/pt-BR.md)

--- a/translations/CATALAN.md
+++ b/translations/CATALAN.md
@@ -9,13 +9,15 @@ Si alguna vegada has fet alguna pregunta que no apareix en aquesta llista, inclo
 
 Traduccions:
 
+- [Arabic](https://github.com/sherifsaleh/reverse-interview/blob/master/translations/ARABIC.md)
+- [Catalan](https://github.com/viraptor/reverse-interview/blob/master/translations/CATALAN.md)
 - Chinese [Simplified](https://github.com/yifeikong/reverse-interview-zh) / [Traditional](https://github.com/NeroCube/reverse-interview-zh-tw/blob/master/README.md)
+- [English](https://github.com/viraptor/reverse-interview/blob/master/README.md)
 - [French](https://github.com/viraptor/reverse-interview/blob/master/translations/FRENCH.md)
 - [Korean](https://github.com/JaeYeopHan/Interview_Question_for_Beginner/blob/master/Reverse_Interview/README.md)
 - [Portuguese (Brazilian)](https://github.com/viraptor/reverse-interview/blob/master/translations/pt-BR.md)
 - [Russian](https://github.com/kix/reverse-interview/blob/master/README.md)
 - [Spanish](https://github.com/felHR85/Entrevista-inversa/blob/master/README.md)
-- [Catalan](https://github.com/viraptor/reverse-interview/blob/master/translations/CATALAN.md)
 
 ## Com utilitzar aquesta llista
 

--- a/translations/FRENCH.md
+++ b/translations/FRENCH.md
@@ -5,6 +5,18 @@ Les points ne sont pas ordonnés et beaucoup peuvent ne pas s'appliquer à un po
 Au départ, il s'agissait de ma liste personnelle de questions, qui s'est allongée au fil du temps pour inclure à la fois des choses que j'aimerais voir plus et des signaux d'alarme que j'aimerais éviter.
 J'ai aussi remarqué le peu de questions posées par les personnes que j'ai interviewées et je pense qu'il s'agissait d'occasions manquées.
 
+Traductions:
+
+- [Arabic](https://github.com/sherifsaleh/reverse-interview/blob/master/translations/ARABIC.md)
+- [Catalan](https://github.com/viraptor/reverse-interview/blob/master/translations/CATALAN.md)
+- Chinese [Simplified](https://github.com/yifeikong/reverse-interview-zh) / [Traditional](https://github.com/NeroCube/reverse-interview-zh-tw/blob/master/README.md)
+- [English](https://github.com/viraptor/reverse-interview/blob/master/README.md)
+- [French](https://github.com/viraptor/reverse-interview/blob/master/translations/FRENCH.md)
+- [Korean](https://github.com/JaeYeopHan/Interview_Question_for_Beginner/blob/master/Reverse_Interview/README.md)
+- [Portuguese (Brazilian)](https://github.com/viraptor/reverse-interview/blob/master/translations/pt-BR.md)
+- [Russian](https://github.com/kix/reverse-interview/blob/master/README.md)
+- [Spanish](https://github.com/felHR85/Entrevista-inversa/blob/master/README.md)
+
 ## Utilisation prévue
    
 - Cochez les questions qui vous intéressent plus particulièrement

--- a/translations/pt-BR.md
+++ b/translations/pt-BR.md
@@ -6,9 +6,13 @@ Se você perguntou algo não listado aqui, mande um PR.
 
 Traduções: 
 
+- [Arábico](https://github.com/sherifsaleh/reverse-interview/blob/master/translations/ARABIC.md)
+- [Catalão](https://github.com/viraptor/reverse-interview/blob/master/translations/CATALAN.md)
 - Chinês [Simplificado](https://github.com/yifeikong/reverse-interview-zh) / [Tradicional](https://github.com/NeroCube/reverse-interview-zh-tw/blob/master/README.md)
-- [Francês](https://github.com/viraptor/reverse-interview/blob/master/translations/FRENCH.md)
+- [Inglês](https://github.com/viraptor/reverse-interview/blob/master/README.md)
+- [Françes](https://github.com/viraptor/reverse-interview/blob/master/translations/FRENCH.md)
 - [Coreano](https://github.com/JaeYeopHan/Interview_Question_for_Beginner/blob/master/Reverse_Interview/README.md)
+- [Português (Brasil)](https://github.com/viraptor/reverse-interview/blob/master/translations/pt-BR.md)
 - [Russo](https://github.com/kix/reverse-interview/blob/master/README.md)
 - [Espanhol](https://github.com/felHR85/Entrevista-inversa/blob/master/README.md)
 


### PR DESCRIPTION
Update the languages translations links present in this repo, according to the english README.md, as follows

- [Arabic](https://github.com/sherifsaleh/reverse-interview/blob/master/translations/ARABIC.md)
- [Catalan](https://github.com/viraptor/reverse-interview/blob/master/translations/CATALAN.md)
- Chinese [Simplified](https://github.com/yifeikong/reverse-interview-zh) / [Traditional](https://github.com/NeroCube/reverse-interview-zh-tw/blob/master/README.md)
- [English](https://github.com/viraptor/reverse-interview/blob/master/README.md)
- [French](https://github.com/viraptor/reverse-interview/blob/master/translations/FRENCH.md)
- [Korean](https://github.com/JaeYeopHan/Interview_Question_for_Beginner/blob/master/Reverse_Interview/README.md)
- [Portuguese (Brazilian)](https://github.com/viraptor/reverse-interview/blob/master/translations/pt-BR.md)
- [Russian](https://github.com/kix/reverse-interview/blob/master/README.md)
- [Spanish](https://github.com/felHR85/Entrevista-inversa/blob/master/README.md)