### PR TITLE
add questions to Catch All

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Having a bug tracking system doesn't make bug handling efficient and CI/CD doesn
 # Catch all
 
 - What's the best and what's the worst aspect of working in this role / team / company?
+- What got you to choose to work for the company initially?
+- What keeps you at the company?
 
 # Compensation
 


### PR DESCRIPTION
I added these to Catch All as it seemed like the best place to put them in the current scheme. Though I can see a new category emerging around the idea of Personal/Rapport for the more one-on-one type questions. Cheers!