### PR TITLE
fr: fix translation of "check"

### DIFF
--- a/translations/FRENCH.md
+++ b/translations/FRENCH.md
@@ -7,11 +7,11 @@ J'ai aussi remarqué le peu de questions posées par les personnes que j'ai inte
 
 ## Utilisation prévue
    
-- Cochez les questions qui vous intéressent plus particulièrement
-- Cochez les réponses que vous pouvez trouver en ligne
-- Sinon, demandez
+- Notez les questions qui vous intéressent plus particulièrement
+- Retirez celles pour lequelles les réponses existent en ligne
+- Posez les questions
 
-N'essayez pas de tout demander sur la liste.
+N'essayez pas de poser toutes les questions de la liste. Respectez le temps de votre intervieweur·se et faites preuve d'initiative en cherchant des réponses par vous même si elles existent déjà en ligne.
 
 Rappelez-vous que les choses ont tendance à être fluides, les réorganisations se produisent souvent.
 Avoir un système de suivi des bogues ne rend pas la gestion des bogues efficace et de l'intégration continue ne signifie pas que votre temps de livraison est nécessairement court. 


### PR DESCRIPTION
"Check" was being translated literally as "put a checkmark on", which made no sense at all. The original meaning seems to be to "make a list of the questions you find interesting" for the first case, and "remove from the list the questions whose answers you can find online" for the other.

Also, fixed the translation of "Definitely don't try to ask everything from the list", which had a weird use of "demander", taking the translation of ask too literally; and added the missing "(Respect the interviewer's time and show initiative by finding answers on your own if they're already published)".